### PR TITLE
RSS-ECOMM-5_17: Prevent rerender of body on non-default route load

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -27,7 +27,7 @@ export class App extends BaseComponent {
   private termsPage: TermsPage = new TermsPage();
   private returnsPage: ReturnsPage = new ReturnsPage();
   private router: Router;
-  private currentPage: BaseComponent = this.homePage;
+  private currentPage: BaseComponent;
 
   private readonly routes = new Map<Route, BaseComponent>([
     [Route.HOME, this.homePage],
@@ -47,6 +47,10 @@ export class App extends BaseComponent {
     this.setupRoutes();
     this.header = new Header();
     this.footer = new Footer();
+
+    const defaultRoute = this.router.getDefaultRoute();
+    this.currentPage = this.routes.get(defaultRoute) || this.errorPage;
+
     this.render();
   }
 

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -4,12 +4,12 @@ import type { ActionHandler } from '@/types/types';
 export class Router {
   private routes: Map<Route, ActionHandler>;
   private homeRoute: Route;
+  private defaultRoute: Route;
 
   constructor(HomeRoute: Route) {
     this.routes = new Map();
     this.homeRoute = HomeRoute;
-
-    this.setDefaultRoute();
+    this.defaultRoute = this.setDefaultRoute();
     this.setEventListeners();
   }
 
@@ -22,19 +22,25 @@ export class Router {
     return validRoutes.has(hash);
   }
 
+  public getDefaultRoute(): Route {
+    return this.defaultRoute;
+  }
+
   public addRoute(route: Route, handler: ActionHandler): void {
     this.routes.set(route, handler);
   }
 
-  private setDefaultRoute(): void {
-    if (!globalThis.location.hash) {
+  private setDefaultRoute(): Route {
+    const currentHash = globalThis.location.hash;
+    if (!currentHash) {
       globalThis.location.hash = this.homeRoute;
+      return this.homeRoute;
     }
+    return Router.checkRouteValidity(currentHash) ? currentHash : Route.ERROR;
   }
 
   private setEventListeners(): void {
     globalThis.addEventListener('hashchange', () => this.handleRoute());
-    window.addEventListener('load', () => this.handleRoute());
   }
 
   private handleRoute(): void {


### PR DESCRIPTION
1. **Task:**
 <!-- Correct link to current task -->
*not applicable*

2. **Screenshot:**
 <!-- Correct screenshots to show the changes if possible -->
*not applicable*

3. **Description:**
- Ensured that the homepage content is not rendered when the page loads for the first time.
- Ensured that the correct Route content is rendered when the page loads for the first time

4. **Checklist:**
 - [X] Changes have been tested locally
 - [X] Proper reviewers have been assigned

5. **Test:**
 - [X] Tests have been added

6. **Notes:**
- closes #137 

