### PR TITLE
RSS-ECOMM-2_16: Add a button or link on the registration page that allows users to navigate to the login page

### DIFF
--- a/src/components/forms/registration/index.ts
+++ b/src/components/forms/registration/index.ts
@@ -3,9 +3,11 @@ import { Button } from '@/components/buttons/button';
 import Input from '@/components/inputs/input';
 import { BTN_TEXT } from '@/constants/constants';
 import { INPUTS_BILLING_DATA, INPUTS_REGISTRATION_DATA } from '@/data';
-import { FORM, REGISTRATION_INPUTS_CONTAINER } from '@/styles/forms/forms';
+import { Router } from '@/router/router';
+import { FORM, REDIRECT_LINK, REGISTRATION_INPUTS_CONTAINER } from '@/styles/forms/forms';
 import { CHECKBOX_CONTAINER_STYLE } from '@/styles/inputs/inputs';
 import { CheckboxText, InputType } from '@/types/enums';
+import { Route } from '@/types/enums';
 import type { InputComponent, RegistrationBody } from '@/types/interfaces';
 import { ElementBuilder } from '@/utils/element-builder';
 
@@ -140,6 +142,21 @@ export default class FormRegistration {
     this.userInfoContainer.append(checkboxDefaultAddress, checkboxSameAddresses);
   }
 
+  private createRedirectLink(): void {
+    const link = new ElementBuilder({
+      tag: 'div',
+      textContent: BTN_TEXT.LOGIN_REDIRECT,
+      className: REDIRECT_LINK,
+      callback: (): void => {
+        Router.followRoute(Route.LOGIN);
+      },
+    }).getElement();
+
+    if (this.form) {
+      this.form.append(link);
+    }
+  }
+
   private render(): void {
     const button = new Button({
       style: 'PRIMARY_PINK',
@@ -153,6 +170,7 @@ export default class FormRegistration {
     this.createCheckboxes();
 
     this.form.append(this.userInfoContainer, button);
+    this.createRedirectLink();
   }
 
   private submitForm(): void {


### PR DESCRIPTION
1. **Task:**
 <!-- Correct link to current task -->
 [RSS-ECOMM-2_16](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint1/RSS-ECOMM-2_16.md)

2. **Screenshot:**
 <!-- Correct screenshots to show the changes if possible -->
![image](https://github.com/user-attachments/assets/7e7e61b7-8769-4497-8635-b49c22b0ec4d)


3. **Description:**
- Added a clear and prominent link on the registration page to navigate to the login page
- Ensured the link is functional and directs the user to the login page.
- Ensured proper handling of navigation and user experience during this process.

4. **Checklist:**
 - [X] Changes have been tested locally
 - [X] Proper reviewers have been assigned

5. **Test:**
 - [X] Tests have been added

6. **Notes:**
- closes #40  

