### PR TITLE
RSS-ECOMM-5_24: Fix missing validation of invalid email formats

### DIFF
--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -45,6 +45,8 @@ export enum ErrorMessages {
   INVALID_DOMAIN = 'Неверный формат домена',
   INVALID_EMAIL = 'Используйте буквы, цифры и специальные символы. Символ «@» обязателен',
   INVALID_FIRST_CHAR = 'Первый символ должен быть буквой или цифрой',
+  INVALID_USING_AT = 'Не должно быть более одного знака @',
+  INVALID_USING_DOTS = 'Некорректный email',
   INVALID_PASSWORD = 'Пароль может содержать только латинские буквы, цифры и специальные символы',
   ONE_DIGIT = 'одну цифру',
   ONE_LOWER_LETTER = 'одну строчную букву',

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -29,6 +29,12 @@ export function validateEMail(string_: string): string | null {
   const rightDomain = /@[\dA-Za-zЁА-яё][\d.A-Za-zЁА-яё-]*\.[A-Za-zЁА-яё]{2,}$/;
   if (!rightDomain.test(string_)) return ErrorMessages.INVALID_DOMAIN;
 
+  const matches = string_.match(/@/g);
+  if (matches && matches.length > 1) return ErrorMessages.INVALID_USING_AT;
+
+  if (/\.{2}/.test(string_)) return ErrorMessages.INVALID_USING_DOTS;
+  if (/\.@/.test(string_)) return ErrorMessages.INVALID_USING_DOTS;
+
   const emailRegex = /^[\dA-Za-zЁА-яё][\w!#$%&'-\]^`{|}~ЁА-яё-]+\.[A-Za-zЁА-яё]{2,}$/;
   if (emailRegex.test(string_)) return null;
 


### PR DESCRIPTION
1. **Task:**
 <!-- Correct link to current task -->
 [RSS-ECOMM-5_24](https://github.com/users/petruse4ka/projects/1/views/1?pane=issue&itemId=111374032&issue=petruse4ka%7CeCommerce-Application%7C164)

2. **Screenshot:**
 
![image](https://github.com/user-attachments/assets/e2b8d2a5-7e22-412e-a5a8-b6870aaf07b2)


3. **Description:**
 Validation should not miss the following invalid email variants:

user@@gmail.com
user@[domain@domain.com](mailto:domain@domain.com)
user@gmail..com
user.@domain.com

4. **Checklist:**
 - [x] Changes have been tested locally
 - [ ] Proper reviewers have been assigned

5. **Test:**
 - [ ] Tests have been added
 - [ ] Tests are not required in this case

6. **Notes:**
 <!-- Any additional notes or comments -->

